### PR TITLE
Guard against conflicting name spaces with other platforms

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -73,6 +73,7 @@ end
     timeout node['yum'][repo]['timeout'] if  node['yum'][repo]['timeout']
     username node['yum'][repo]['username'] if node['yum'][repo]['username']
 
+    only_if { platform_family?('fedora') }
     action :create
   end
 end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'yum-fedora::default' do
   context 'yum-fedora::default uses default attributes' do
     let(:chef_run) do
-      ChefSpec::ServerRunner.new do |node|
+      ChefSpec::ServerRunner.new(platform: 'fedora', version: 21) do |node|
         node.set['yum']['fedora']['managed'] = true
         node.set['yum']['fedora-debuginfo']['managed'] = true
         node.set['yum']['fedora-source']['managed'] = true


### PR DESCRIPTION
This should resolve #3  which was encountered if you created a cookbook that includes both yum-fedora and yum-centos in the metadata. The updates repository has a namespace conflict which copies the incorrect information into the repo file potentially.